### PR TITLE
Remove the universal macOS target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
           - filename: tertestrial_macos_intel_64
             target: x86_64-apple-darwin
             os: macos-latest
-          - filename: tertestrial_macos_universal
-            target: universal-apple-darwin
-            os: macos-latest
           # NOTE: Tertestrial doesn't run on Windows yet due to the Unix-specific FIFO library
           # - filename: tertestrial_windows_intel_64
           #   target: x86_64-pc-windows-msvc


### PR DESCRIPTION
People know which CPU they have.