### PR TITLE
Handle inability to calculate variable gracefully

### DIFF
--- a/features/custom_vars/current_or_above_line_content.feature
+++ b/features/custom_vars/current_or_above_line_content.feature
@@ -43,7 +43,7 @@ Feature: define a custom variable with a regex match of the file content
     When receiving the command '{ "command": "testFileLine", "file": "foo.rs", "line": 1 }'
     Then it prints
       """
-      Error: Did not find pattern \bfn (\w+)\( in file foo.rs at line 1
+      Did not find pattern \bfn (\w+)\( in file foo.rs at line 1
       """
 
   Scenario: receiving a matching file and no location

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ fn run_command(
         filename: _,
         line: _,
       } => {
+        // user triggered a command in a place where it doesn't match all regexes --> let them know and go to the correct location
         cli::print_error(&err);
         return Ok(false);
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,22 @@ fn run_command(
 ) -> Result<bool> {
   let trigger = Trigger::parse(text)?;
   let command = match configuration.get_command(&trigger, last_command) {
-    Err(err) if err == UserError::NoCommandToRepeat => {
-      // repeat non-existing command --> don't stop, just print an error message and keep going
-      cli::print_error(&err);
-      return Ok(false);
-    }
-    Err(err) => return Err(err),
+    Err(err) => match err {
+      UserError::NoCommandToRepeat => {
+        // repeat non-existing command --> don't stop, just print an error message and keep going
+        cli::print_error(&err);
+        return Ok(false);
+      }
+      UserError::TriggerRegexNotFound {
+        regex: _,
+        filename: _,
+        line: _,
+      } => {
+        cli::print_error(&err);
+        return Ok(false);
+      }
+      _ => return Err(err),
+    },
     Ok(command) => command,
   };
   last_command.replace(command.clone());


### PR DESCRIPTION
There are legitimate situations where we want Tertestrial to keep running after this, for example when the user sends this command on the wrong line.